### PR TITLE
Fixed name of ts-json-feature Eclipse project

### DIFF
--- a/update-site/ts-json-feature/.project
+++ b/update-site/ts-json-feature/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>ts-jsdt-feature</name>
+	<name>ts-json-feature</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
The wrong name prevents the project from appearing in Eclipse.