### PR TITLE
Warn about incompatibility between compileOnSave and path mapping

### DIFF
--- a/core/ts.core/src/ts/cmd/tsc/CompilerOptions.java
+++ b/core/ts.core/src/ts/cmd/tsc/CompilerOptions.java
@@ -1,6 +1,11 @@
 package ts.cmd.tsc;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import ts.cmd.AbstractOptions;
 
@@ -49,12 +54,14 @@ public class CompilerOptions extends AbstractOptions {
 	private String out;
 	private String outDir;
 	private String outFile;
+	private Map<String, List<String>> paths;
 	private boolean preserveConstEnums;
 	private boolean pretty;
 	private String project;
 	private String reactNamespace;
 	private boolean removeComments;
 	private String rootDir;
+	private List<String> rootDirs;
 	private boolean skipDefaultLibCheck;
 	private boolean sourceMap;
 	private String sourceRoot;
@@ -820,6 +827,49 @@ public class CompilerOptions extends AbstractOptions {
 	}
 
 	/**
+	 * Specify path mapping to be computed relative to baseUrl option.
+	 * 
+	 * @return key patterns to which paths are mapped.
+	 */
+	public Set<String> getPathsKeys() {
+		if (paths == null) {
+			return Collections.emptySet();
+		}
+		return Collections.unmodifiableSet(paths.keySet());
+	}
+
+	/**
+	 * Specify path mapping to be computed relative to baseUrl option.
+	 * 
+	 * @param pathsKey
+	 *            a path key pattern.
+	 * @return paths mapped to the key pattern.
+	 */
+	public List<String> getPathsKeyValues(String pathsKey) {
+		if (paths == null) {
+			return Collections.emptyList();
+		}
+		List<String> values = paths.get(pathsKey);
+		if (values == null) {
+			return Collections.emptyList();
+		}
+		return Collections.unmodifiableList(values);
+	}
+
+	/**
+	 * Specify path mapping to be computed relative to baseUrl option.
+	 * 
+	 * @param paths
+	 */
+	public void setPaths(Map<String, List<String>> paths) {
+		Map<String, List<String>> pathsCopy = new HashMap<>(paths.size());
+		for (Map.Entry<String, List<String>> entry : paths.entrySet()) {
+			pathsCopy.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+		}
+		this.paths = pathsCopy;
+	}
+
+	/**
 	 * Do not erase const enum declarations in generated code. See const enums
 	 * https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#94-constant-enum-declarations
 	 * documentation for more details.
@@ -937,6 +987,27 @@ public class CompilerOptions extends AbstractOptions {
 	 */
 	public void setRootDir(String rootDir) {
 		this.rootDir = rootDir;
+	}
+
+	/**
+	 * Specify list of root directory to be used when resolving modules.
+	 * 
+	 * @return
+	 */
+	public List<String> getRootDirs() {
+		if (rootDirs == null) {
+			return Collections.emptyList();
+		}
+		return Collections.unmodifiableList(rootDirs);
+	}
+
+	/**
+	 * Specify list of root directory to be used when resolving modules.
+	 * 
+	 * @param rootDirs
+	 */
+	public void setRootDirs(List<String> rootDirs) {
+		this.rootDirs = new ArrayList<>(rootDirs);
 	}
 
 	/**

--- a/core/ts.core/src/ts/resources/jsonconfig/TsconfigJson.java
+++ b/core/ts.core/src/ts/resources/jsonconfig/TsconfigJson.java
@@ -142,6 +142,36 @@ public class TsconfigJson {
 	}
 
 	/**
+	 * Returns true if the "compilerOptions" defines "paths" and false
+	 * otherwise.
+	 * 
+	 * @return true if the "compilerOptions" defines "paths" and false
+	 *         otherwise.
+	 */
+	public boolean hasPaths() {
+		CompilerOptions options = getCompilerOptions();
+		if (options == null) {
+			return false;
+		}
+		return !options.getPathsKeys().isEmpty();
+	}
+
+	/**
+	 * Returns true if the "compilerOptions" defines "rootDirs" and false
+	 * otherwise.
+	 * 
+	 * @return true if the "compilerOptions" defines "rootDirs" and false
+	 *         otherwise.
+	 */
+	public boolean hasRootDirs() {
+		CompilerOptions options = getCompilerOptions();
+		if (options == null) {
+			return false;
+		}
+		return !options.getRootDirs().isEmpty();
+	}
+
+	/**
 	 * Returns the defined "exclude" list from the tsconfig.json other exclude
 	 * by default "node_modules" and "bower_components".
 	 * 

--- a/eclipse/ts.eclipse.ide.core/src/ts/eclipse/ide/internal/core/TypeScriptCoreMessages.java
+++ b/eclipse/ts.eclipse.ide.core/src/ts/eclipse/ide/internal/core/TypeScriptCoreMessages.java
@@ -33,6 +33,7 @@ public class TypeScriptCoreMessages extends NLS {
 	public static String tsconfig_compileOnSave_disable_error;
 	public static String tsconfig_compilation_context_error;
 	public static String tsconfig_cannot_use_compileOnSave_with_outFile_error;
+	public static String tsconfig_cannot_use_compileOnSave_with_path_mapping_error;
 
 	// Launch
 	public static String TypeScriptCompilerLaunchConfigurationDelegate_invalidBuildPath;

--- a/eclipse/ts.eclipse.ide.core/src/ts/eclipse/ide/internal/core/TypeScriptCoreMessages.properties
+++ b/eclipse/ts.eclipse.ide.core/src/ts/eclipse/ide/internal/core/TypeScriptCoreMessages.properties
@@ -17,6 +17,7 @@ SaveProjectPreferencesJob_taskName=Saving preferences of project {0}
 tsconfig_compileOnSave_disable_error=TypeScript file cannot be compiled on save because tsconfig.json disable it. If this is not intended, please set "compileOnSave" to "true" of your "{0}" file.
 tsconfig_compilation_context_error=TypeScript file is not included in the TypeScript compilation context. If this is not intended, please check the "files" or "filesGlob" section of your "{0}" file.
 tsconfig_cannot_use_compileOnSave_with_outFile_error=TypeScript file cannot be compiled on save because tsconfig.json defines "out"/outFile". If this is not intended, please set "buildOnSave" to "true" of your "{0}" file.
+tsconfig_cannot_use_compileOnSave_with_path_mapping_error=TypeScript file cannot be compiled on save because tsconfig.json uses path mapping features ("paths", "rootDirs"). If this is not intended, please set "buildOnSave" to "true" of your "{0}" file.
 
 # Launch
 TypeScriptCompilerLaunchConfigurationDelegate_invalidBuildPath=The tsconfig file {0} does not exist for the compiler launch named {1}.


### PR DESCRIPTION
Recent versions of TypeScript added compiler options `paths` and `rootDirs` that cannot be specified on the command line. They are marked in the [Compiler Options documentation](https://www.typescriptlang.org/docs/handbook/compiler-options.html).

Since the _Compile on Save_ feature is invoking `tsc` from the command line, those two options are inherently incompatible with Compile on Save.

As you can see in [this test project](https://github.com/angelozerr/typescript.java/files/744587/TestPathMapping.zip), using the `paths` option causes an error when compiling `main.ts` on save, while it works perfectly when using _Build on Save_.

In the proposed fix, I'm adding a check that marks the files with a warning when Compile on Save is used together with the problematic options. The experience is similar to when the use has `outFile` configured.