### PR TITLE
Show problem status in editor icon

### DIFF
--- a/eclipse/jsdt/ts.eclipse.ide.jsdt.ui/src/ts/eclipse/ide/jsdt/internal/ui/JSDTTypeScriptUIImages.java
+++ b/eclipse/jsdt/ts.eclipse.ide.jsdt.ui/src/ts/eclipse/ide/jsdt/internal/ui/JSDTTypeScriptUIImages.java
@@ -1,0 +1,74 @@
+/**
+ *  Copyright (c) 2015-2016 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Lorenzo Dalla Vecchia <lorenzo.dallavecchia@webratio.com> - initial API and implementation
+ */
+package ts.eclipse.ide.jsdt.internal.ui;
+
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.viewers.DecorationOverlayIcon;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.ui.ISharedImages;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.osgi.framework.Bundle;
+
+/**
+ * Image registry for JSDT TypeScript UI plugin.
+ */
+public enum JSDTTypeScriptUIImages {
+
+	TSFILE("icons/full/obj16/ts.png"),
+
+	TSFILE_W_ERROR(TSFILE, null, null, getSharedImageDescriptor(ISharedImages.IMG_DEC_FIELD_ERROR), null),
+
+	TSFILE_W_WARNING(TSFILE, null, null, getSharedImageDescriptor(ISharedImages.IMG_DEC_FIELD_WARNING), null),
+
+	;
+
+	private JSDTTypeScriptUIImages(String path) {
+		Bundle bundle = JSDTTypeScriptUIPlugin.getDefault().getBundle();
+		ImageDescriptor descr = AbstractUIPlugin.imageDescriptorFromPlugin(bundle.getSymbolicName(), path);
+		JFaceResources.getImageRegistry().put(key(), descr);
+	}
+
+	private JSDTTypeScriptUIImages(JSDTTypeScriptUIImages base, ImageDescriptor tlOverlay, ImageDescriptor trOverlay,
+			ImageDescriptor blOverlay, ImageDescriptor brOverlay) {
+		ImageDescriptor descr = new DecorationOverlayIcon(base.get(),
+				new ImageDescriptor[] { tlOverlay, trOverlay, blOverlay, brOverlay });
+		JFaceResources.getImageRegistry().put(key(), descr);
+	}
+
+	private static ImageDescriptor getSharedImageDescriptor(String key) {
+		return PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(key);
+	}
+
+	private String key() {
+		return JSDTTypeScriptUIImages.class.getName() + "." + name();
+	}
+
+	/**
+	 * Gets the image object associated with this image type.
+	 * 
+	 * @return
+	 */
+	public Image get() {
+		return JFaceResources.getImageRegistry().get(key());
+	}
+
+	/**
+	 * Gets the image descriptor object associated with this image type.
+	 * 
+	 * @return
+	 */
+	public ImageDescriptor getDescriptor() {
+		return JFaceResources.getImageRegistry().getDescriptor(key());
+	}
+
+}

--- a/eclipse/jsdt/ts.eclipse.ide.jsdt.ui/src/ts/eclipse/ide/jsdt/internal/ui/editor/ProblemTickUpdater.java
+++ b/eclipse/jsdt/ts.eclipse.ide.jsdt.ui/src/ts/eclipse/ide/jsdt/internal/ui/editor/ProblemTickUpdater.java
@@ -1,0 +1,94 @@
+/**
+ *  Copyright (c) 2015-2016 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Lorenzo Dalla Vecchia <lorenzo.dallavecchia@webratio.com> - initial API and implementation
+ */
+package ts.eclipse.ide.jsdt.internal.ui.editor;
+
+import java.util.Objects;
+import java.util.Set;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.ui.IEditorInput;
+
+import ts.eclipse.ide.core.TypeScriptCorePlugin;
+import ts.eclipse.ide.core.resources.problems.IProblemChangeListener;
+import ts.eclipse.ide.jsdt.internal.ui.JSDTTypeScriptUIImages;
+import ts.eclipse.ide.jsdt.internal.ui.JSDTTypeScriptUIPlugin;
+
+final class ProblemTickUpdater {
+
+	private final TypeScriptEditor editor;
+	private final IProblemChangeListener problemChangeListener;
+
+	ProblemTickUpdater(TypeScriptEditor editor) {
+		this.editor = Objects.requireNonNull(editor);
+		this.problemChangeListener = new IProblemChangeListener() {
+			@Override
+			public void problemsChanged(Set<IResource> changedResources) {
+				handleChangedProblems(changedResources);
+			}
+		};
+		TypeScriptCorePlugin.getProblemManager().addProblemChangedListener(problemChangeListener);
+	}
+
+	void dispose() {
+		TypeScriptCorePlugin.getProblemManager().removeProblemChangedListener(problemChangeListener);
+	}
+
+	public void update() {
+		updateTitleImageForResource(getEditorInputResource());
+	}
+
+	private void handleChangedProblems(Set<IResource> changedResources) {
+		IResource inputResource = getEditorInputResource();
+		if (changedResources.contains(inputResource)) {
+			updateTitleImageForResource(inputResource);
+		}
+	}
+
+	private IResource getEditorInputResource() {
+		IEditorInput input = editor.getEditorInput();
+		if (input == null) {
+			return null;
+		}
+		return input.getAdapter(IResource.class);
+	}
+
+	private void updateTitleImageForResource(IResource resource) {
+		if (resource == null || !resource.isAccessible()) {
+			editor.updateTitleImage(null);
+			return;
+		}
+
+		// Determine the current maximum problem severity
+		int severity;
+		try {
+			severity = resource.findMaxProblemSeverity(IMarker.PROBLEM, true, 0);
+		} catch (CoreException e) {
+			JSDTTypeScriptUIPlugin.log(e);
+			return;
+		}
+
+		// Prepare the image
+		Image image;
+		if (severity == IMarker.SEVERITY_ERROR) {
+			image = JSDTTypeScriptUIImages.TSFILE_W_ERROR.get();
+		} else if (severity == IMarker.SEVERITY_WARNING) {
+			image = JSDTTypeScriptUIImages.TSFILE_W_WARNING.get();
+		} else {
+			image = JSDTTypeScriptUIImages.TSFILE.get();
+		}
+
+		editor.updateTitleImage(image);
+	}
+
+}

--- a/eclipse/jsdt/ts.eclipse.ide.jsdt.ui/src/ts/eclipse/ide/jsdt/internal/ui/editor/TypeScriptEditor.java
+++ b/eclipse/jsdt/ts.eclipse.ide.jsdt.ui/src/ts/eclipse/ide/jsdt/internal/ui/editor/TypeScriptEditor.java
@@ -7,6 +7,7 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ *  Lorenzo Dalla Vecchia <lorenzo.dallavecchia@webratio.com> - problem tick in title image
  */
 package ts.eclipse.ide.jsdt.internal.ui.editor;
 
@@ -56,6 +57,7 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IWindowListener;
@@ -182,6 +184,13 @@ public class TypeScriptEditor extends JavaScriptLightWeightEditor implements IEd
 	 */
 	private TypeScriptContentOutlinePage contentOutlinePage;
 
+	private final ProblemTickUpdater problemTickUpdater;
+
+	public TypeScriptEditor() {
+		super();
+		this.problemTickUpdater = new ProblemTickUpdater(this);
+	}
+
 	protected ActionGroup getActionGroup() {
 		return fActionGroups;
 	}
@@ -291,6 +300,8 @@ public class TypeScriptEditor extends JavaScriptLightWeightEditor implements IEd
 	public void dispose() {
 		super.dispose();
 
+		problemTickUpdater.dispose();
+
 		if (fActionGroups != null) {
 			fActionGroups.dispose();
 			fActionGroups = null;
@@ -306,6 +317,10 @@ public class TypeScriptEditor extends JavaScriptLightWeightEditor implements IEd
 			PlatformUI.getWorkbench().removeWindowListener(fActivationListener);
 			fActivationListener = null;
 		}
+	}
+
+	void updateTitleImage(Image titleImage) {
+		setTitleImage(titleImage);
 	}
 
 	@Override
@@ -856,6 +871,7 @@ public class TypeScriptEditor extends JavaScriptLightWeightEditor implements IEd
 	@Override
 	protected void doSetInput(IEditorInput input) throws CoreException {
 		super.doSetInput(input);
+		problemTickUpdater.update();
 		configureToggleCommentAction();
 		// try {
 		// //IDocument document = getSourceViewer().getDocument();

--- a/eclipse/ts.eclipse.ide.core/META-INF/MANIFEST.MF
+++ b/eclipse/ts.eclipse.ide.core/META-INF/MANIFEST.MF
@@ -31,6 +31,7 @@ Export-Package: ts.eclipse.ide.core,
  ts.eclipse.ide.core.resources,
  ts.eclipse.ide.core.resources.buildpath,
  ts.eclipse.ide.core.resources.jsconfig,
+ ts.eclipse.ide.core.resources.problems,
  ts.eclipse.ide.core.resources.watcher,
  ts.eclipse.ide.core.tslint,
  ts.eclipse.ide.core.utils

--- a/eclipse/ts.eclipse.ide.core/src/ts/eclipse/ide/core/TypeScriptCorePlugin.java
+++ b/eclipse/ts.eclipse.ide.core/src/ts/eclipse/ide/core/TypeScriptCorePlugin.java
@@ -7,6 +7,7 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ *  Lorenzo Dalla Vecchia <lorenzo.dallavecchia@webratio.com> - getter for ProblemManager
  */
 package ts.eclipse.ide.core;
 
@@ -23,10 +24,12 @@ import org.osgi.framework.BundleContext;
 import ts.eclipse.ide.core.nodejs.INodejsInstallManager;
 import ts.eclipse.ide.core.repository.IIDETypeScriptRepositoryManager;
 import ts.eclipse.ide.core.resources.ITypeScriptElementChangedListener;
+import ts.eclipse.ide.core.resources.problems.IProblemManager;
 import ts.eclipse.ide.core.resources.watcher.IResourcesWatcher;
 import ts.eclipse.ide.internal.core.nodejs.NodejsInstallManager;
 import ts.eclipse.ide.internal.core.repository.IDETypeScriptRepositoryManager;
 import ts.eclipse.ide.internal.core.resources.IDEResourcesManager;
+import ts.eclipse.ide.internal.core.resources.problems.ProblemManager;
 import ts.eclipse.ide.internal.core.resources.watcher.ResourcesWatcher;
 import ts.resources.ConfigurableTypeScriptResourcesManager;
 
@@ -124,6 +127,10 @@ public class TypeScriptCorePlugin extends Plugin {
 
 	public static IResourcesWatcher getResourcesWatcher() {
 		return ResourcesWatcher.getInstance();
+	}
+
+	public static IProblemManager getProblemManager() {
+		return ProblemManager.getInstance();
 	}
 
 	public void addTypeScriptElementChangedListener(ITypeScriptElementChangedListener listener) {

--- a/eclipse/ts.eclipse.ide.core/src/ts/eclipse/ide/core/resources/problems/IProblemChangeListener.java
+++ b/eclipse/ts.eclipse.ide.core/src/ts/eclipse/ide/core/resources/problems/IProblemChangeListener.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright (c) 2015-2016 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Lorenzo Dalla Vecchia <lorenzo.dallavecchia@webratio.com> - initial API and implementation
+ */
+package ts.eclipse.ide.core.resources.problems;
+
+import java.util.Set;
+
+import org.eclipse.core.resources.IResource;
+
+/**
+ * Listener that is notified after changes occur in the TypeScript problems of
+ * workspace resources.
+ */
+public interface IProblemChangeListener {
+
+	/**
+	 * Called when problems change.
+	 * 
+	 * @param changedResources
+	 *            set of resources on which problems have changed. This also
+	 *            includes containers where the <i>combined</i> problem status
+	 *            may have changed because of changes in the contained files or
+	 *            sub-containers.
+	 */
+	public void problemsChanged(Set<IResource> changedResources);
+
+}

--- a/eclipse/ts.eclipse.ide.core/src/ts/eclipse/ide/core/resources/problems/IProblemManager.java
+++ b/eclipse/ts.eclipse.ide.core/src/ts/eclipse/ide/core/resources/problems/IProblemManager.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright (c) 2015-2016 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Lorenzo Dalla Vecchia <lorenzo.dallavecchia@webratio.com> - initial API and implementation
+ */
+package ts.eclipse.ide.core.resources.problems;
+
+/**
+ * Manager for getting updates about the global state of TypeScript problems on
+ * workspace resources.
+ */
+public interface IProblemManager {
+
+	/**
+	 * Adds a listener to be notified when problems change on workspace
+	 * resources.
+	 * 
+	 * @param listener
+	 *            listener to notify.
+	 */
+	public void addProblemChangedListener(IProblemChangeListener listener);
+
+	/**
+	 * Removes a problem change listener previously added via
+	 * {@link #addProblemChangedListener}.
+	 * 
+	 * @param listener
+	 *            listener to remove.
+	 */
+	public void removeProblemChangedListener(IProblemChangeListener listener);
+
+}

--- a/eclipse/ts.eclipse.ide.core/src/ts/eclipse/ide/internal/core/resources/problems/ProblemManager.java
+++ b/eclipse/ts.eclipse.ide.core/src/ts/eclipse/ide/internal/core/resources/problems/ProblemManager.java
@@ -1,0 +1,178 @@
+/**
+ *  Copyright (c) 2015-2016 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Lorenzo Dalla Vecchia <lorenzo.dallavecchia@webratio.com> - initial API and implementation
+ */
+package ts.eclipse.ide.internal.core.resources.problems;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IMarkerDelta;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceChangeListener;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.IResourceDeltaVisitor;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ISafeRunnable;
+import org.eclipse.core.runtime.SafeRunner;
+
+import ts.eclipse.ide.core.TypeScriptCorePlugin;
+import ts.eclipse.ide.core.resources.problems.IProblemChangeListener;
+import ts.eclipse.ide.core.resources.problems.IProblemManager;
+
+/**
+ * Implementation of {@link IProblemManager}.
+ */
+public class ProblemManager implements IProblemManager {
+
+	private static final ProblemManager INSTANCE = new ProblemManager();
+
+	public static ProblemManager getInstance() {
+		return INSTANCE;
+	}
+
+	private final IResourceChangeListener resourceChangeListener;
+	private final List<IProblemChangeListener> listeners;
+
+	private ProblemManager() {
+		this.resourceChangeListener = new IResourceChangeListener() {
+			@Override
+			public void resourceChanged(IResourceChangeEvent event) {
+				handleResourceChanged(event);
+			}
+		};
+
+		this.listeners = new CopyOnWriteArrayList<>();
+	}
+
+	public synchronized void shutdown() {
+		this.listeners.clear();
+		ResourcesPlugin.getWorkspace().removeResourceChangeListener(resourceChangeListener);
+	}
+
+	@Override
+	public synchronized void addProblemChangedListener(IProblemChangeListener listener) {
+		this.listeners.add(Objects.requireNonNull(listener));
+		if (this.listeners.size() == 1) {
+			ResourcesPlugin.getWorkspace().addResourceChangeListener(resourceChangeListener);
+		}
+	}
+
+	@Override
+	public synchronized void removeProblemChangedListener(IProblemChangeListener listener) {
+		this.listeners.remove(listener);
+		if (this.listeners.isEmpty()) {
+			ResourcesPlugin.getWorkspace().removeResourceChangeListener(resourceChangeListener);
+		}
+	}
+
+	private void handleResourceChanged(IResourceChangeEvent event) {
+		IResourceDelta delta = event.getDelta();
+		if (delta == null) {
+			return;
+		}
+
+		// Find resourced whose problems changed and report them to listeners
+		Set<IResource> changedResources = new HashSet<>();
+		try {
+			delta.accept(new ProblemMarkerDeltaVisitor(changedResources));
+		} catch (CoreException e) {
+			TypeScriptCorePlugin.logError(e);
+		}
+		if (!changedResources.isEmpty()) {
+			notifyListeners(Collections.unmodifiableSet(changedResources));
+		}
+	}
+
+	private static class ProblemMarkerDeltaVisitor implements IResourceDeltaVisitor {
+
+		private final Set<IResource> changedResources;
+
+		public ProblemMarkerDeltaVisitor(Set<IResource> changedResources) {
+			this.changedResources = Objects.requireNonNull(changedResources);
+		}
+
+		@Override
+		public boolean visit(IResourceDelta delta) throws CoreException {
+			IResource resource = delta.getResource();
+			if (resource instanceof IProject && delta.getKind() == IResourceDelta.CHANGED) {
+				IProject project = (IProject) resource;
+				if (!project.isAccessible()) {
+					return false; // skip closed projects
+				}
+			}
+			checkInvalidate(delta, resource);
+			return true;
+		}
+
+		private void checkInvalidate(IResourceDelta delta, IResource resource) {
+			int kind = delta.getKind();
+			if (kind == IResourceDelta.REMOVED || kind == IResourceDelta.ADDED
+					|| (kind == IResourceDelta.CHANGED && isProblemDelta(delta))) {
+
+				// Invalidate the resource and all its ancestors
+				for (IResource r = resource; r != null; r = r.getParent()) {
+					boolean added = changedResources.add(r);
+					if (!added) {
+						break;
+					}
+				}
+			}
+		}
+
+		private boolean isProblemDelta(IResourceDelta delta) {
+			if ((delta.getFlags() & IResourceDelta.MARKERS) == 0) {
+				return false;
+			}
+			for (IMarkerDelta markerDelta : delta.getMarkerDeltas()) {
+				if (markerDelta.isSubtypeOf(IMarker.PROBLEM)) {
+
+					// Detect added/removed problem markers
+					int kind = markerDelta.getKind();
+					if (kind == IResourceDelta.ADDED || kind == IResourceDelta.REMOVED) {
+						return true;
+					}
+
+					// Detect changes in problem marker severity
+					int oldSeverity = markerDelta.getAttribute(IMarker.SEVERITY, -1);
+					int newSeverity = markerDelta.getMarker().getAttribute(IMarker.SEVERITY, -1);
+					if (newSeverity != oldSeverity) {
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+	}
+
+	private void notifyListeners(Set<IResource> changedResources) {
+		for (IProblemChangeListener listener : listeners) {
+			SafeRunner.run(new ISafeRunnable() {
+				@Override
+				public void run() throws Exception {
+					listener.problemsChanged(changedResources);
+				}
+
+				@Override
+				public void handleException(Throwable exception) {
+					// logged by SafeRunner
+				}
+			});
+		}
+	}
+
+}


### PR DESCRIPTION
This commit enables display of problem marker status in the TypeScript editor icon. Whenever markers change on the edited files (as a result of Compile/Build on Save), the editor icon is changed accordingly.

![problemtick](https://cloud.githubusercontent.com/assets/15628014/22504964/31abfe52-e879-11e6-9d30-739c1a52fe57.png)