### PR TITLE
Keep projects open on tsserver via OpenExternalProject

### DIFF
--- a/core/ts.core/src/ts/client/CommandNames.java
+++ b/core/ts.core/src/ts/client/CommandNames.java
@@ -7,6 +7,7 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ *  Lorenzo Dalla Vecchia <lorenzo.dallavecchia@webratio.com> - openExternalProject
  */
 package ts.client;
 
@@ -36,6 +37,7 @@ public enum CommandNames {
 	Configure("configure"),
 	ProjectInfo("projectInfo"),
 	Rename("rename"),
+	OpenExternalProject("openExternalProject"),
 	
 	// 2.0.3
 	SemanticDiagnosticsSync("semanticDiagnosticsSync", "2.0.3"), 

--- a/core/ts.core/src/ts/client/ITypeScriptServiceClient.java
+++ b/core/ts.core/src/ts/client/ITypeScriptServiceClient.java
@@ -7,7 +7,7 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
- *  Lorenzo Dalla Vecchia <lorenzo.dallavecchia@webratio.com> - adjusted usage of CompletableFuture
+ *  Lorenzo Dalla Vecchia <lorenzo.dallavecchia@webratio.com> - adjusted usage of CompletableFuture, openExternalProject
  */
 package ts.client;
 
@@ -197,6 +197,16 @@ public interface ITypeScriptServiceClient {
 	void configure(ConfigureRequestArguments arguments) throws TypeScriptException;
 
 	CompletableFuture<ProjectInfo> projectInfo(String file, String projectFileName, boolean needFileNameList);
+
+	/**
+	 * Defines a TypeScript project that is "handled by the client" and
+	 * therefore never closed automatically by the server.
+	 * 
+	 * @param projectFileName
+	 * @param rootFileNames
+	 * @return
+	 */
+	CompletableFuture<Void> openExternalProject(String projectFileName, List<String> rootFileNames);
 
 	// Since 2.0.3
 

--- a/core/ts.core/src/ts/client/ITypeScriptServiceClient.java
+++ b/core/ts.core/src/ts/client/ITypeScriptServiceClient.java
@@ -7,6 +7,7 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ *  Lorenzo Dalla Vecchia <lorenzo.dallavecchia@webratio.com> - adjusted usage of CompletableFuture
  */
 package ts.client;
 
@@ -77,8 +78,8 @@ public interface ITypeScriptServiceClient {
 	 * @param insertString
 	 * @throws TypeScriptException
 	 */
-	// void changeFile(String fileName, int position, int endPosition, String
-	// insertString) throws TypeScriptException;
+	// void changeFile(String fileName, int position, int
+	// endPosition, String insertString) throws TypeScriptException;
 
 	/**
 	 * Change file content at the given lines/offsets.
@@ -102,10 +103,9 @@ public interface ITypeScriptServiceClient {
 	 * @param fileName
 	 * @param position
 	 * @return completion for the given fileName at the given position.
-	 * @throws TypeScriptException
 	 */
 	// CompletableFuture<List<CompletionEntry>> completions(String fileName, int
-	// position) throws TypeScriptException;
+	// position);
 
 	/**
 	 * Completion for the given fileName at the given line/offset.
@@ -114,16 +114,14 @@ public interface ITypeScriptServiceClient {
 	 * @param line
 	 * @param offset
 	 * @return completion for the given fileName at the given line/offset
-	 * @throws TypeScriptException
 	 */
-	CompletableFuture<List<CompletionEntry>> completions(String fileName, int line, int offset)
-			throws TypeScriptException;
+	CompletableFuture<List<CompletionEntry>> completions(String fileName, int line, int offset);
 
 	CompletableFuture<List<CompletionEntry>> completions(String name, int line, int offset,
-			ICompletionEntryFactory instanceCreator) throws TypeScriptException;
+			ICompletionEntryFactory instanceCreator);
 
 	CompletableFuture<List<CompletionEntryDetails>> completionEntryDetails(String fileName, int line, int offset,
-			String[] entryNames, CompletionEntry completionEntry) throws TypeScriptException;
+			String[] entryNames, CompletionEntry completionEntry);
 
 	/**
 	 * Definition for the given fileName at the given line/offset.
@@ -132,9 +130,8 @@ public interface ITypeScriptServiceClient {
 	 * @param line
 	 * @param offset
 	 * @return
-	 * @throws TypeScriptException
 	 */
-	CompletableFuture<List<FileSpan>> definition(String fileName, int line, int offset) throws TypeScriptException;
+	CompletableFuture<List<FileSpan>> definition(String fileName, int line, int offset);
 
 	/**
 	 * Signature help for the given fileName at the given line/offset.
@@ -143,10 +140,8 @@ public interface ITypeScriptServiceClient {
 	 * @param line
 	 * @param offset
 	 * @return
-	 * @throws TypeScriptException
 	 */
-	CompletableFuture<SignatureHelpItems> signatureHelp(String fileName, int line, int offset)
-			throws TypeScriptException;
+	CompletableFuture<SignatureHelpItems> signatureHelp(String fileName, int line, int offset);
 
 	/**
 	 * Quick info for the given fileName at the given line/offset.
@@ -155,14 +150,12 @@ public interface ITypeScriptServiceClient {
 	 * @param line
 	 * @param offset
 	 * @return
-	 * @throws TypeScriptException
 	 */
-	CompletableFuture<QuickInfo> quickInfo(String fileName, int line, int offset) throws TypeScriptException;
+	CompletableFuture<QuickInfo> quickInfo(String fileName, int line, int offset);
 
-	CompletableFuture<List<DiagnosticEvent>> geterr(String[] files, int delay) throws TypeScriptException;
+	CompletableFuture<List<DiagnosticEvent>> geterr(String[] files, int delay);
 
-	CompletableFuture<List<DiagnosticEvent>> geterrForProject(String file, int delay, ProjectInfo projectInfo)
-			throws TypeScriptException;
+	CompletableFuture<List<DiagnosticEvent>> geterrForProject(String file, int delay, ProjectInfo projectInfo);
 
 	/**
 	 * Format for the given fileName at the given line/offset.
@@ -173,10 +166,8 @@ public interface ITypeScriptServiceClient {
 	 * @param endLine
 	 * @param endOffset
 	 * @return
-	 * @throws TypeScriptException
 	 */
-	CompletableFuture<List<CodeEdit>> format(String fileName, int line, int offset, int endLine, int endOffset)
-			throws TypeScriptException;
+	CompletableFuture<List<CodeEdit>> format(String fileName, int line, int offset, int endLine, int endOffset);
 
 	/**
 	 * Find references for the given fileName at the given line/offset.
@@ -185,10 +176,8 @@ public interface ITypeScriptServiceClient {
 	 * @param line
 	 * @param offset
 	 * @return
-	 * @throws TypeScriptException
 	 */
-	CompletableFuture<ReferencesResponseBody> references(String fileName, int line, int offset)
-			throws TypeScriptException;
+	CompletableFuture<ReferencesResponseBody> references(String fileName, int line, int offset);
 
 	/**
 	 * Find occurrences for the given fileName at the given line/offset.
@@ -197,21 +186,17 @@ public interface ITypeScriptServiceClient {
 	 * @param line
 	 * @param offset
 	 * @return
-	 * @throws TypeScriptException
 	 */
-	CompletableFuture<List<OccurrencesResponseItem>> occurrences(String fileName, int line, int offset)
-			throws TypeScriptException;
+	CompletableFuture<List<OccurrencesResponseItem>> occurrences(String fileName, int line, int offset);
 
 	CompletableFuture<RenameResponseBody> rename(String file, int line, int offset, Boolean findInComments,
-			Boolean findInStrings) throws TypeScriptException;
+			Boolean findInStrings);
 
-	CompletableFuture<List<NavigationBarItem>> navbar(String fileName, IPositionProvider positionProvider)
-			throws TypeScriptException;
+	CompletableFuture<List<NavigationBarItem>> navbar(String fileName, IPositionProvider positionProvider);
 
 	void configure(ConfigureRequestArguments arguments) throws TypeScriptException;
 
-	CompletableFuture<ProjectInfo> projectInfo(String file, String projectFileName, boolean needFileNameList)
-			throws TypeScriptException;
+	CompletableFuture<ProjectInfo> projectInfo(String file, String projectFileName, boolean needFileNameList);
 
 	// Since 2.0.3
 
@@ -220,42 +205,35 @@ public interface ITypeScriptServiceClient {
 	 * 
 	 * @param includeLinePosition
 	 * @return
-	 * @throws TypeScriptException
 	 */
-	CompletableFuture<DiagnosticEventBody> semanticDiagnosticsSync(String file, Boolean includeLinePosition)
-			throws TypeScriptException;
+	CompletableFuture<DiagnosticEventBody> semanticDiagnosticsSync(String file, Boolean includeLinePosition);
 
 	/**
 	 * Execute syntactic diagnostics for the given file.
 	 * 
 	 * @param includeLinePosition
 	 * @return
-	 * @throws TypeScriptException
 	 */
-	CompletableFuture<DiagnosticEventBody> syntacticDiagnosticsSync(String file, Boolean includeLinePosition)
-			throws TypeScriptException;
+	CompletableFuture<DiagnosticEventBody> syntacticDiagnosticsSync(String file, Boolean includeLinePosition);
 
 	// Since 2.0.5
 
-	CompletableFuture<Boolean> compileOnSaveEmitFile(String fileName, Boolean forced) throws TypeScriptException;
+	CompletableFuture<Boolean> compileOnSaveEmitFile(String fileName, Boolean forced);
 
-	CompletableFuture<List<CompileOnSaveAffectedFileListSingleProject>> compileOnSaveAffectedFileList(String fileName)
-			throws TypeScriptException;
+	CompletableFuture<List<CompileOnSaveAffectedFileListSingleProject>> compileOnSaveAffectedFileList(String fileName);
 
 	// Since 2.0.6
 
-	CompletableFuture<NavigationBarItem> navtree(String fileName, IPositionProvider positionProvider)
-			throws TypeScriptException;
+	CompletableFuture<NavigationBarItem> navtree(String fileName, IPositionProvider positionProvider);
 
-	CompletableFuture<TextInsertion> docCommentTemplate(String fileName, int line, int offset)
-			throws TypeScriptException;
+	CompletableFuture<TextInsertion> docCommentTemplate(String fileName, int line, int offset);
 
 	// Since 2.1.0
 
 	CompletableFuture<List<CodeAction>> getCodeFixes(String fileName, IPositionProvider positionProvider, int startLine,
-			int startOffset, int endLine, int endOffset, List<Integer> errorCodes) throws TypeScriptException;
+			int startOffset, int endLine, int endOffset, List<Integer> errorCodes);
 
-	CompletableFuture<List<String>> getSupportedCodeFixes() throws TypeScriptException;
+	CompletableFuture<List<String>> getSupportedCodeFixes();
 
 	//
 	/**
@@ -265,9 +243,8 @@ public interface ITypeScriptServiceClient {
 	 * @param line
 	 * @param offset
 	 * @return
-	 * @throws TypeScriptException
 	 */
-	CompletableFuture<List<FileSpan>> implementation(String fileName, int line, int offset) throws TypeScriptException;
+	CompletableFuture<List<FileSpan>> implementation(String fileName, int line, int offset);
 
 	void addClientListener(ITypeScriptClientListener listener);
 

--- a/core/ts.core/src/ts/client/TypeScriptServiceClient.java
+++ b/core/ts.core/src/ts/client/TypeScriptServiceClient.java
@@ -7,6 +7,7 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ *  Lorenzo Dalla Vecchia <lorenzo.dallavecchia@webratio.com> - adjusted usage of CompletableFuture, added required requests
  */
 package ts.client;
 
@@ -16,6 +17,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
@@ -127,31 +130,39 @@ public class TypeScriptServiceClient implements ITypeScriptServiceClient {
 			if (message.startsWith("{")) {
 				TypeScriptServiceClient.this.dispatchMessage(message);
 			}
-		};
+		}
 
 	};
 
-	private static class PendingRequestInfo {
-		Request<?> requestMessage;
-		Consumer<Response<?>> responseHandler;
-		long startTime;
+	private static abstract class RequestInfo {
+		final Request<?> requestMessage;
+		final long startTime;
+		final CompletableFuture<?> requiredResult;
 
-		PendingRequestInfo(Request<?> requestMessage, Consumer<Response<?>> responseHandler) {
+		RequestInfo(Request<?> requestMessage, CompletableFuture<?> requiredResult) {
 			this.requestMessage = requestMessage;
-			this.responseHandler = responseHandler;
 			this.startTime = System.nanoTime();
+			this.requiredResult = requiredResult;
 		}
 	}
 
-	private static class PendingRequestEventInfo {
-		Request<?> requestMessage;
-		Consumer<Event<?>> eventHandler;
-		long startTime;
+	private static class PendingRequestInfo extends RequestInfo {
+		final Consumer<Response<?>> responseHandler;
 
-		PendingRequestEventInfo(Request<?> requestMessage, Consumer<Event<?>> eventHandler) {
-			this.requestMessage = requestMessage;
+		PendingRequestInfo(Request<?> requestMessage, Consumer<Response<?>> responseHandler,
+				CompletableFuture<?> requiredResult) {
+			super(requestMessage, requiredResult);
+			this.responseHandler = responseHandler;
+		}
+	}
+
+	private static class PendingRequestEventInfo extends RequestInfo {
+		final Consumer<Event<?>> eventHandler;
+
+		PendingRequestEventInfo(Request<?> requestMessage, Consumer<Event<?>> eventHandler,
+				CompletableFuture<?> requiredResult) {
+			super(requestMessage, requiredResult);
 			this.eventHandler = eventHandler;
-			this.startTime = System.nanoTime();
 		}
 	}
 
@@ -276,18 +287,17 @@ public class TypeScriptServiceClient implements ITypeScriptServiceClient {
 
 	@Override
 	public void openFile(String fileName, String content, ScriptKindName scriptKindName) throws TypeScriptException {
-		execute(new OpenRequest(fileName, null, content, scriptKindName), false);
+		waitForFuture(executeNoResult(new OpenRequest(fileName, null, content, scriptKindName)));
 	}
 
 	@Override
 	public void closeFile(String fileName) throws TypeScriptException {
-		execute(new CloseRequest(fileName), false);
+		waitForFuture(executeNoResult(new CloseRequest(fileName)));
 	}
 
 	// @Override
 	// public void changeFile(String fileName, int position, int endPosition,
-	// String insertString)
-	// throws TypeScriptException {
+	// String insertString) {
 	// execute(new ChangeRequest(fileName, position, endPosition, insertString),
 	// false);
 	// }
@@ -295,7 +305,7 @@ public class TypeScriptServiceClient implements ITypeScriptServiceClient {
 	@Override
 	public void changeFile(String fileName, int line, int offset, int endLine, int endOffset, String insertString)
 			throws TypeScriptException {
-		execute(new ChangeRequest(fileName, line, offset, endLine, endOffset, insertString), false);
+		waitForFuture(executeNoResult(new ChangeRequest(fileName, line, offset, endLine, endOffset, insertString)));
 	}
 
 	/**
@@ -310,7 +320,7 @@ public class TypeScriptServiceClient implements ITypeScriptServiceClient {
 		int seq = SequenceHelper.getRequestSeq();
 		String tempFileName = FileTempHelper.updateTempFile(newText, seq);
 		try {
-			execute(new ReloadRequest(fileName, tempFileName, seq), true).get(5000, TimeUnit.MILLISECONDS);
+			execute(new ReloadRequest(fileName, tempFileName, seq)).get(5000, TimeUnit.MILLISECONDS);
 		} catch (Exception e) {
 			if (e instanceof TypeScriptException) {
 				throw (TypeScriptException) e;
@@ -321,114 +331,101 @@ public class TypeScriptServiceClient implements ITypeScriptServiceClient {
 
 	// @Override
 	// public CompletableFuture<List<CompletionEntry>> completions(String
-	// fileName, int position)
-	// throws TypeScriptException {
-	// return execute(new CompletionsRequest(fileName, position), true);
+	// fileName, int position) {
+	// return execute(new CompletionsRequest(fileName, position));
 	// }
 
 	@Override
-	public CompletableFuture<List<CompletionEntry>> completions(String fileName, int line, int offset)
-			throws TypeScriptException {
+	public CompletableFuture<List<CompletionEntry>> completions(String fileName, int line, int offset) {
 		return completions(fileName, line, offset, ICompletionEntryFactory.DEFAULT);
 	}
 
 	@Override
 	public CompletableFuture<List<CompletionEntry>> completions(String fileName, int line, int offset,
-			ICompletionEntryFactory factory) throws TypeScriptException {
+			ICompletionEntryFactory factory) {
 		return execute(
-				new CompletionsRequest(fileName, line, offset, getCompletionEntryMatcherProvider(), this, factory),
-				true);
+				new CompletionsRequest(fileName, line, offset, getCompletionEntryMatcherProvider(), this, factory));
 	}
 
 	@Override
 	public CompletableFuture<List<CompletionEntryDetails>> completionEntryDetails(String fileName, int line, int offset,
-			String[] entryNames, CompletionEntry completionEntry) throws TypeScriptException {
-		return execute(new CompletionDetailsRequest(fileName, line, offset, null, entryNames), true);
+			String[] entryNames, CompletionEntry completionEntry) {
+		return execute(new CompletionDetailsRequest(fileName, line, offset, null, entryNames));
 	}
 
 	@Override
-	public CompletableFuture<List<FileSpan>> definition(String fileName, int line, int offset)
-			throws TypeScriptException {
-		return execute(new DefinitionRequest(fileName, line, offset), true);
+	public CompletableFuture<List<FileSpan>> definition(String fileName, int line, int offset) {
+		return execute(new DefinitionRequest(fileName, line, offset));
 	}
 
 	@Override
-	public CompletableFuture<SignatureHelpItems> signatureHelp(String fileName, int line, int offset)
-			throws TypeScriptException {
-		return execute(new SignatureHelpRequest(fileName, line, offset), true);
+	public CompletableFuture<SignatureHelpItems> signatureHelp(String fileName, int line, int offset) {
+		return execute(new SignatureHelpRequest(fileName, line, offset));
 	}
 
 	@Override
-	public CompletableFuture<QuickInfo> quickInfo(String fileName, int line, int offset) throws TypeScriptException {
-		return execute(new QuickInfoRequest(fileName, line, offset), true);
+	public CompletableFuture<QuickInfo> quickInfo(String fileName, int line, int offset) {
+		return execute(new QuickInfoRequest(fileName, line, offset));
 	}
 
 	@Override
-	public CompletableFuture<List<DiagnosticEvent>> geterr(String[] files, int delay) throws TypeScriptException {
-		return execute(new GeterrRequest(files, delay), true);
+	public CompletableFuture<List<DiagnosticEvent>> geterr(String[] files, int delay) {
+		return execute(new GeterrRequest(files, delay));
 	}
 
 	@Override
-	public CompletableFuture<List<DiagnosticEvent>> geterrForProject(String file, int delay, ProjectInfo projectInfo)
-			throws TypeScriptException {
-		return execute(new GeterrForProjectRequest(file, delay, projectInfo), true);
+	public CompletableFuture<List<DiagnosticEvent>> geterrForProject(String file, int delay, ProjectInfo projectInfo) {
+		return execute(new GeterrForProjectRequest(file, delay, projectInfo));
 	}
 
 	@Override
-	public CompletableFuture<List<CodeEdit>> format(String fileName, int line, int offset, int endLine, int endOffset)
-			throws TypeScriptException {
-		return execute(new FormatRequest(fileName, line, offset, endLine, endOffset), true);
+	public CompletableFuture<List<CodeEdit>> format(String fileName, int line, int offset, int endLine, int endOffset) {
+		return execute(new FormatRequest(fileName, line, offset, endLine, endOffset));
 	}
 
 	@Override
-	public CompletableFuture<ReferencesResponseBody> references(String fileName, int line, int offset)
-			throws TypeScriptException {
-		return execute(new ReferencesRequest(fileName, line, offset), true);
+	public CompletableFuture<ReferencesResponseBody> references(String fileName, int line, int offset) {
+		return execute(new ReferencesRequest(fileName, line, offset));
 	}
 
 	@Override
-	public CompletableFuture<List<OccurrencesResponseItem>> occurrences(String fileName, int line, int offset)
-			throws TypeScriptException {
-		return execute(new OccurrencesRequest(fileName, line, offset), true);
+	public CompletableFuture<List<OccurrencesResponseItem>> occurrences(String fileName, int line, int offset) {
+		return execute(new OccurrencesRequest(fileName, line, offset));
 	}
 
 	@Override
 	public CompletableFuture<RenameResponseBody> rename(String file, int line, int offset, Boolean findInComments,
-			Boolean findInStrings) throws TypeScriptException {
-		return execute(new RenameRequest(file, line, offset, findInComments, findInStrings), true);
+			Boolean findInStrings) {
+		return execute(new RenameRequest(file, line, offset, findInComments, findInStrings));
 	}
 
 	@Override
-	public CompletableFuture<List<NavigationBarItem>> navbar(String fileName, IPositionProvider positionProvider)
-			throws TypeScriptException {
-		return execute(new NavBarRequest(fileName, positionProvider), true);
+	public CompletableFuture<List<NavigationBarItem>> navbar(String fileName, IPositionProvider positionProvider) {
+		return execute(new NavBarRequest(fileName, positionProvider));
 	}
 
 	@Override
 	public void configure(ConfigureRequestArguments arguments) throws TypeScriptException {
-		execute(new ConfigureRequest(arguments), true);
+		waitForFuture(execute(new ConfigureRequest(arguments)));
 	}
 
 	@Override
-	public CompletableFuture<ProjectInfo> projectInfo(String file, String projectFileName, boolean needFileNameList)
-			throws TypeScriptException {
-		return execute(new ProjectInfoRequest(file, needFileNameList), true);
+	public CompletableFuture<ProjectInfo> projectInfo(String file, String projectFileName, boolean needFileNameList) {
+		return execute(new ProjectInfoRequest(file, needFileNameList));
 	}
 
 	// Since 2.0.3
 
 	@Override
-	public CompletableFuture<DiagnosticEventBody> semanticDiagnosticsSync(String file, Boolean includeLinePosition)
-			throws TypeScriptException {
-		return execute(new SemanticDiagnosticsSyncRequest(file, includeLinePosition), true).thenApply(d -> {
+	public CompletableFuture<DiagnosticEventBody> semanticDiagnosticsSync(String file, Boolean includeLinePosition) {
+		return execute(new SemanticDiagnosticsSyncRequest(file, includeLinePosition)).thenApply(d -> {
 			return new DiagnosticEventBody(file, (List<Diagnostic>) d);
 		});
 	}
 
 	@Override
-	public CompletableFuture<DiagnosticEventBody> syntacticDiagnosticsSync(String file, Boolean includeLinePosition)
-			throws TypeScriptException {
-		return execute(new SyntacticDiagnosticsSyncRequest(file, includeLinePosition), true).thenApply(d -> {
+	public CompletableFuture<DiagnosticEventBody> syntacticDiagnosticsSync(String file, Boolean includeLinePosition) {
+		return execute(new SyntacticDiagnosticsSyncRequest(file, includeLinePosition)).thenApply(d -> {
 			return new DiagnosticEventBody(file, (List<Diagnostic>) d);
 		});
 	}
@@ -436,105 +433,191 @@ public class TypeScriptServiceClient implements ITypeScriptServiceClient {
 	// Since 2.0.5
 
 	@Override
-	public CompletableFuture<Boolean> compileOnSaveEmitFile(String fileName, Boolean forced)
-			throws TypeScriptException {
-		return execute(new CompileOnSaveEmitFileRequest(fileName, forced), true);
+	public CompletableFuture<Boolean> compileOnSaveEmitFile(String fileName, Boolean forced) {
+		return execute(new CompileOnSaveEmitFileRequest(fileName, forced));
 	}
 
 	@Override
 	public CompletableFuture<List<CompileOnSaveAffectedFileListSingleProject>> compileOnSaveAffectedFileList(
-			String fileName) throws TypeScriptException {
-		return execute(new CompileOnSaveAffectedFileListRequest(fileName), true);
+			String fileName) {
+		return execute(new CompileOnSaveAffectedFileListRequest(fileName));
 	}
 
 	// Since 2.0.6
 
 	@Override
-	public CompletableFuture<NavigationBarItem> navtree(String fileName, IPositionProvider positionProvider)
-			throws TypeScriptException {
-		return execute(new NavTreeRequest(fileName, positionProvider), true);
+	public CompletableFuture<NavigationBarItem> navtree(String fileName, IPositionProvider positionProvider) {
+		return execute(new NavTreeRequest(fileName, positionProvider));
 	}
 
 	@Override
-	public CompletableFuture<TextInsertion> docCommentTemplate(String fileName, int line, int offset)
-			throws TypeScriptException {
-		return execute(new DocCommentTemplateRequest(fileName, line, offset), true);
+	public CompletableFuture<TextInsertion> docCommentTemplate(String fileName, int line, int offset) {
+		return execute(new DocCommentTemplateRequest(fileName, line, offset));
 	}
-	
+
 	// Since 2.1.0
 
 	@Override
 	public CompletableFuture<List<CodeAction>> getCodeFixes(String fileName, IPositionProvider positionProvider,
-			int startLine, int startOffset, int endLine, int endOffset, List<Integer> errorCodes)
-			throws TypeScriptException {
-		return execute(new CodeFixRequest(fileName, startLine, startOffset, endLine, endOffset, errorCodes), true);
+			int startLine, int startOffset, int endLine, int endOffset, List<Integer> errorCodes) {
+		return execute(new CodeFixRequest(fileName, startLine, startOffset, endLine, endOffset, errorCodes));
 	}
 
 	@Override
-	public CompletableFuture<List<String>> getSupportedCodeFixes() throws TypeScriptException {
-		return execute(new GetSupportedCodeFixesRequest(), true);
+	public CompletableFuture<List<String>> getSupportedCodeFixes() {
+		return execute(new GetSupportedCodeFixesRequest());
 	}
 
 	@Override
-	public CompletableFuture<List<FileSpan>> implementation(String fileName, int line, int offset)
-			throws TypeScriptException {
-		return execute(new ImplementationRequest(fileName, line, offset), true);
+	public CompletableFuture<List<FileSpan>> implementation(String fileName, int line, int offset) {
+		return execute(new ImplementationRequest(fileName, line, offset));
 	}
 
-	private <T> CompletableFuture<T> execute(Request<?> request, boolean expectsResult) throws TypeScriptException {
-		if (!expectsResult) {
-			sendRequest(request);
-			return null;
-		}
-		final CompletableFuture<T> result = new CompletableFuture<T>() {
+	/**
+	 * Executes a request that does not expect a result. A future is returned
+	 * (even if there is no result) in order to handle the possible waiting for
+	 * required requests and for their exceptions.
+	 * 
+	 * @param request
+	 */
+	private CompletableFuture<Void> executeNoResult(Request<?> request) {
+		return this._execute(request, false, false);
+	}
 
-			@Override
-			public boolean cancel(boolean mayInterruptIfRunning) {
+	/**
+	 * Executes a request that expects a result. The waiting for any pending
+	 * request is chained with the completable future result that the caller has
+	 * to handle anyway.
+	 * 
+	 * @param request
+	 * @return
+	 */
+	private <T> CompletableFuture<T> execute(Request<?> request) {
+		return this._execute(request, true, false);
+	}
+
+	/**
+	 * Executes a request that expects a result, causing all subsequent requests
+	 * to wait for this one to complete.
+	 * 
+	 * @param request
+	 * @return
+	 */
+	private <T> CompletableFuture<T> executeCausingWait(Request<?> request) {
+		return this._execute(request, true, true);
+	}
+
+	private <T> CompletableFuture<T> _execute(Request<?> request, boolean expectsResult, boolean causesWait) {
+
+		// prepare a future for waiting for all required requests
+		final CompletableFuture<?> requiredFuture = computeRequiredRequestsFuture();
+
+		// send the request after waiting for previous required requests
+		return requiredFuture.thenCompose(requiredResult -> {
+			CompletableFuture<T> result = new CompletableFuture<>();
+
+			// augment the future with response handling, if expected
+			if (expectsResult) {
+				// remove request info after completing exceptionally
+				result.whenComplete((requestResult, e) -> {
+					if (e != null) {
+						if (request instanceof IRequestEventable) {
+							List<String> keys = ((IRequestEventable) request).getKeys();
+							synchronized (receivedRequestMap) {
+								for (String key : keys) {
+									receivedRequestMap.remove(key);
+								}
+							}
+						} else {
+							synchronized (sentRequestMap) {
+								sentRequestMap.remove(request.getSeq());
+							}
+						}
+					}
+				});
+				// register request info in maps for handling the result
 				if (request instanceof IRequestEventable) {
+					Consumer<Event<?>> responseHandler = (event) -> {
+						if (((IRequestEventable) request).accept(event)) {
+							result.complete((T) ((IRequestEventable) request).getEvents());
+						}
+					};
 					List<String> keys = ((IRequestEventable) request).getKeys();
+					PendingRequestEventInfo info = new PendingRequestEventInfo(request, responseHandler,
+							causesWait ? result : null);
 					synchronized (receivedRequestMap) {
 						for (String key : keys) {
-							receivedRequestMap.remove(key);
+							receivedRequestMap.put(key, info);
 						}
 					}
 				} else {
+					Consumer<Response<?>> responseHandler = (response) -> {
+						if (response.isSuccess()) {
+							// tsserver response with success
+							result.complete((T) response.getBody());
+						} else {
+							// tsserver response with error
+							result.completeExceptionally(createException(response.getMessage()));
+						}
+					};
+					int seq = request.getSeq();
 					synchronized (sentRequestMap) {
-						sentRequestMap.remove(request.getSeq());
+						sentRequestMap.put(seq,
+								new PendingRequestInfo(request, responseHandler, causesWait ? result : null));
 					}
 				}
-				return super.cancel(mayInterruptIfRunning);
 			}
-		};
-		if (request instanceof IRequestEventable) {
-			Consumer<Event<?>> responseHandler = (event) -> {
-				if (((IRequestEventable) request).accept(event)) {
-					result.complete((T) ((IRequestEventable) request).getEvents());
-				}
-			};
-			List<String> keys = ((IRequestEventable) request).getKeys();
-			PendingRequestEventInfo info = new PendingRequestEventInfo(request, responseHandler);
-			synchronized (receivedRequestMap) {
-				for (String key : keys) {
-					receivedRequestMap.put(key, info);
-				}
+
+			// send the request
+			try {
+				sendRequest(request);
+			} catch (TypeScriptException e) {
+				result.completeExceptionally(e);
 			}
-		} else {
-			Consumer<Response<?>> responseHandler = (response) -> {
-				if (response.isSuccess()) {
-					// tsserver response with success
-					result.complete((T) response.getBody());
-				} else {
-					// tsserver response with error
-					result.completeExceptionally(createException(response.getMessage()));
-				}
-			};
-			int seq = request.getSeq();
+
+			// complete immediately, if no result expected
+			if (!expectsResult) {
+				result.complete(null);
+			}
+
+			return result;
+		});
+	}
+
+	private CompletableFuture<Void> computeRequiredRequestsFuture() {
+		synchronized (receivedRequestMap) {
 			synchronized (sentRequestMap) {
-				sentRequestMap.put(seq, new PendingRequestInfo(request, responseHandler));
+				if (receivedRequestMap.isEmpty() && sentRequestMap.isEmpty()) {
+					return CompletableFuture.completedFuture(null);
+				}
+				List<CompletableFuture<?>> cfs = new ArrayList<>();
+				for (RequestInfo info : receivedRequestMap.values()) {
+					if (info.requiredResult != null) {
+						cfs.add(info.requiredResult);
+					}
+				}
+				for (RequestInfo info : sentRequestMap.values()) {
+					if (info.requiredResult != null) {
+						cfs.add(info.requiredResult);
+					}
+				}
+				return CompletableFuture.allOf(cfs.toArray(new CompletableFuture<?>[cfs.size()]));
 			}
 		}
-		sendRequest(request);
-		return result;
+	}
+
+	private static <T> T waitForFuture(Future<T> future) throws TypeScriptException {
+		try {
+			return future.get(5000, TimeUnit.MILLISECONDS);
+		} catch (ExecutionException e) {
+			Throwable cause = e.getCause();
+			if (cause instanceof TypeScriptException) {
+				throw (TypeScriptException) cause;
+			}
+			throw new TypeScriptException(cause);
+		} catch (Exception e) {
+			throw new TypeScriptException(e);
+		}
 	}
 
 	private TypeScriptException createException(String message) {

--- a/core/ts.core/src/ts/client/TypeScriptServiceClient.java
+++ b/core/ts.core/src/ts/client/TypeScriptServiceClient.java
@@ -7,7 +7,7 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
- *  Lorenzo Dalla Vecchia <lorenzo.dallavecchia@webratio.com> - adjusted usage of CompletableFuture, added required requests
+ *  Lorenzo Dalla Vecchia <lorenzo.dallavecchia@webratio.com> - adjusted usage of CompletableFuture, added required requests, openExternalProject
  */
 package ts.client;
 
@@ -72,6 +72,7 @@ import ts.internal.client.protocol.MessageType;
 import ts.internal.client.protocol.NavBarRequest;
 import ts.internal.client.protocol.NavTreeRequest;
 import ts.internal.client.protocol.OccurrencesRequest;
+import ts.internal.client.protocol.OpenExternalProjectRequest;
 import ts.internal.client.protocol.OpenRequest;
 import ts.internal.client.protocol.ProjectInfoRequest;
 import ts.internal.client.protocol.QuickInfoRequest;
@@ -230,7 +231,10 @@ public class TypeScriptServiceClient implements ITypeScriptServiceClient {
 					// message " + json);
 					return;
 				}
-				Response responseMessage = pendingRequestInfo.requestMessage.parseResponse(json);
+				Response<?> responseMessage = pendingRequestInfo.requestMessage.parseResponse(json);
+				if (responseMessage == null) {
+					responseMessage = GsonHelper.DEFAULT_GSON.fromJson(json, Response.class);
+				}
 				try {
 					handleResponse(responseMessage, message, pendingRequestInfo.startTime);
 					pendingRequestInfo.responseHandler.accept(responseMessage);
@@ -412,6 +416,11 @@ public class TypeScriptServiceClient implements ITypeScriptServiceClient {
 	@Override
 	public CompletableFuture<ProjectInfo> projectInfo(String file, String projectFileName, boolean needFileNameList) {
 		return execute(new ProjectInfoRequest(file, needFileNameList));
+	}
+
+	@Override
+	public CompletableFuture<Void> openExternalProject(String projectFileName, List<String> rootFileNames) {
+		return executeCausingWait(new OpenExternalProjectRequest(projectFileName, rootFileNames));
 	}
 
 	// Since 2.0.3

--- a/core/ts.core/src/ts/client/external/ExternalFile.java
+++ b/core/ts.core/src/ts/client/external/ExternalFile.java
@@ -1,0 +1,30 @@
+/**
+ *  Copyright (c) 2015-2017 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Lorenzo Dalla Vecchia <lorenzo.dallavecchia@webratio.com> - initial API and implementation
+ */
+package ts.client.external;
+
+/**
+ * Represents a file in external project.
+ */
+public class ExternalFile {
+	/**
+	 * Name of file
+	 */
+	private String fileName;
+
+	public ExternalFile(String fileName) {
+		this.fileName = fileName;
+	}
+
+	public String getFileName() {
+		return fileName;
+	}
+
+}

--- a/core/ts.core/src/ts/client/external/ExternalProject.java
+++ b/core/ts.core/src/ts/client/external/ExternalProject.java
@@ -1,0 +1,51 @@
+/**
+ *  Copyright (c) 2015-2017 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Lorenzo Dalla Vecchia <lorenzo.dallavecchia@webratio.com> - initial API and implementation
+ */
+package ts.client.external;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents an external project
+ */
+public class ExternalProject {
+	/**
+	 * Project name
+	 */
+	private String projectFileName;
+	/**
+	 * List of root files in project
+	 */
+	private List<ExternalFile> rootFiles;
+	/**
+	 * Compiler options for the project
+	 */
+	private ExternalProjectCompilerOptions options;
+
+	public ExternalProject(String projectFileName, List<ExternalFile> rootFiles) {
+		this.projectFileName = projectFileName;
+		this.rootFiles = new ArrayList<ExternalFile>(rootFiles);
+	}
+
+	public String getProjectFileName() {
+		return projectFileName;
+	}
+
+	public List<ExternalFile> getRootFiles() {
+		return Collections.unmodifiableList(rootFiles);
+	}
+
+	public ExternalProjectCompilerOptions getOptions() {
+		return options;
+	}
+
+}

--- a/core/ts.core/src/ts/client/external/ExternalProjectCompilerOptions.java
+++ b/core/ts.core/src/ts/client/external/ExternalProjectCompilerOptions.java
@@ -1,0 +1,19 @@
+/**
+ *  Copyright (c) 2015-2017 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Lorenzo Dalla Vecchia <lorenzo.dallavecchia@webratio.com> - initial API and implementation
+ */
+package ts.client.external;
+
+/**
+ * For external projects, some of the project settings are sent together with
+ * compiler settings.
+ */
+public class ExternalProjectCompilerOptions {
+
+}

--- a/core/ts.core/src/ts/internal/client/protocol/OpenExternalProjectRequest.java
+++ b/core/ts.core/src/ts/internal/client/protocol/OpenExternalProjectRequest.java
@@ -1,0 +1,43 @@
+/**
+ *  Copyright (c) 2015-2017 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Lorenzo Dalla Vecchia <lorenzo.dallavecchia@webratio.com> - initial API and implementation
+ */
+package ts.internal.client.protocol;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.google.gson.JsonObject;
+
+import ts.client.CommandNames;
+import ts.client.external.ExternalFile;
+import ts.client.external.ExternalProject;
+
+/**
+ * A request to open or update external project.
+ * 
+ * @see https://github.com/Microsoft/TypeScript/blob/master/src/server/protocol.ts
+ */
+public class OpenExternalProjectRequest extends Request<ExternalProject> {
+
+	public OpenExternalProjectRequest(String projectFileName, List<String> rootFileNames) {
+		super(CommandNames.OpenExternalProject.getName(),
+				new ExternalProject(projectFileName, createExternalFileList(rootFileNames)));
+	}
+
+	private static List<ExternalFile> createExternalFileList(List<String> fileNames) {
+		return fileNames.stream().map(ExternalFile::new).collect(Collectors.toList());
+	}
+
+	@Override
+	public Response<Boolean> parseResponse(JsonObject json) {
+		return GsonHelper.DEFAULT_GSON.fromJson(json, OpenExternalProjectResponse.class);
+	}
+
+}

--- a/core/ts.core/src/ts/internal/client/protocol/OpenExternalProjectResponse.java
+++ b/core/ts.core/src/ts/internal/client/protocol/OpenExternalProjectResponse.java
@@ -1,0 +1,21 @@
+/**
+ *  Copyright (c) 2015-2017 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Lorenzo Dalla Vecchia <lorenzo.dallavecchia@webratio.com> - initial API and implementation
+ */
+package ts.internal.client.protocol;
+
+/**
+ * Response to OpenExternalProjectRequest request. This is just an
+ * acknowledgement, so no body field is required.
+ * 
+ * @see https://github.com/Microsoft/TypeScript/blob/master/src/server/protocol.ts
+ */
+public class OpenExternalProjectResponse extends Response<Boolean> {
+
+}

--- a/eclipse/ts.eclipse.ide.core/src/ts/eclipse/ide/internal/core/resources/IDETypeScriptProject.java
+++ b/eclipse/ts.eclipse.ide.core/src/ts/eclipse/ide/internal/core/resources/IDETypeScriptProject.java
@@ -7,6 +7,7 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ *  Lorenzo Dalla Vecchia <lorenzo.dallavecchia@webratio.com> - openExternalProject
  */
 package ts.eclipse.ide.internal.core.resources;
 
@@ -349,6 +350,17 @@ public class IDETypeScriptProject extends TypeScriptProject implements IIDETypeS
 		buildPath = null;
 		ITypeScriptBuildPath newBuildPath = getTypeScriptBuildPath();
 		IDEResourcesManager.getInstance().fireBuildPathChanged(this, oldBuildPath, newBuildPath);
+	}
+
+	@Override
+	protected List<String> getTsconfigFilePaths() {
+		ITsconfigBuildPath[] tsconfigBuildPaths = getTypeScriptBuildPath().getTsconfigBuildPaths();
+		List<String> result = new ArrayList<>(tsconfigBuildPaths.length);
+		for (ITsconfigBuildPath tsconfigBuildPath : tsconfigBuildPaths) {
+			IFile tsconfigFile = tsconfigBuildPath.getTsconfigFile();
+			result.add(WorkbenchResourceUtil.getRelativePath(tsconfigFile, tsconfigFile.getProject()).toString());
+		}
+		return result;
 	}
 
 	@Override

--- a/eclipse/ts.eclipse.ide.core/src/ts/eclipse/ide/internal/core/resources/IDETypeScriptProject.java
+++ b/eclipse/ts.eclipse.ide.core/src/ts/eclipse/ide/internal/core/resources/IDETypeScriptProject.java
@@ -388,13 +388,12 @@ public class IDETypeScriptProject extends TypeScriptProject implements IIDETypeS
 	@Override
 	public void compileWithTsserver(List<IFile> updatedTsFiles, List<IFile> removedTsFiles, IProgressMonitor monitor)
 			throws TypeScriptException {
-		List<IFile> tsFilesToClosed = new ArrayList<>();
 		try {
 			List<String> tsFilesToCompile = new ArrayList<>();
 			// Collect ts files to compile by using tsserver to retrieve
 			// dependencies files.
 			// It works only if tsconfig.json declares "compileOnSave: true".
-			if (collectTsFilesToCompile(updatedTsFiles, getClient(), tsFilesToCompile, tsFilesToClosed, false,
+			if (collectTsFilesToCompile(updatedTsFiles, getClient(), tsFilesToCompile, false,
 					monitor)) {
 				return;
 			}
@@ -411,10 +410,6 @@ public class IDETypeScriptProject extends TypeScriptProject implements IIDETypeS
 			throw e;
 		} catch (Exception e) {
 			throw new TypeScriptException(e);
-		} finally {
-			for (IFile tsFile : tsFilesToClosed) {
-				closeFile(tsFile);
-			}
 		}
 	}
 
@@ -429,7 +424,7 @@ public class IDETypeScriptProject extends TypeScriptProject implements IIDETypeS
 	 * @throws Exception
 	 */
 	private boolean collectTsFilesToCompile(List<IFile> tsFiles, ITypeScriptServiceClient client,
-			List<String> tsFilesToCompile, List<IFile> tsFilesToClosed, boolean exclude, IProgressMonitor monitor)
+			List<String> tsFilesToCompile, boolean exclude, IProgressMonitor monitor)
 			throws Exception {
 		for (IFile tsFile : tsFiles) {
 			if (monitor.isCanceled()) {
@@ -437,14 +432,6 @@ public class IDETypeScriptProject extends TypeScriptProject implements IIDETypeS
 			}
 			String filename = WorkbenchResourceUtil.getFileName(tsFile);
 			if (!tsFilesToCompile.contains(filename)) {
-				// tsserver needs that file must be opened, force the "open"
-				// if file is not opened.
-				// see
-				// https://github.com/angelozerr/typescript.java/issues/142
-				if (getOpenedFile(tsFile) == null) {
-					openFile(tsFile, null);
-					tsFilesToClosed.add(tsFile);
-				}
 				collectTsFilesToCompile(filename, client, tsFilesToCompile, exclude);
 			}
 		}


### PR DESCRIPTION
This change makes tsserver aware of existing Eclipse projects, so that it does not forget about project state when all files are closed.
Closes #142.