### PR TITLE
Changed API of AbstractNewProjectWizard

### DIFF
--- a/eclipse/terminal/ts.eclipse.ide.terminal.interpreter.npm/src/ts/eclipse/ide/terminal/interpreter/npm/internal/commands/NpmInstallCommandInterpreter.java
+++ b/eclipse/terminal/ts.eclipse.ide.terminal.interpreter.npm/src/ts/eclipse/ide/terminal/interpreter/npm/internal/commands/NpmInstallCommandInterpreter.java
@@ -22,6 +22,8 @@ public class NpmInstallCommandInterpreter extends AbstractCommandInterpreter {
 
 	private final String NODE_MODULES = "node_modules";
 
+	private final int MAX_REFRESH_FOLDERS	= 20;		// If there are more FOlders, the whole "node_modules" will be refreshed
+
 	private final List<String> folders;
 
 	public NpmInstallCommandInterpreter(String workingDir) {
@@ -52,9 +54,13 @@ public class NpmInstallCommandInterpreter extends AbstractCommandInterpreter {
 
 				private List<IResource> getResources(IProgressMonitor monitor) throws CoreException {
 					List<IResource> resources = new ArrayList<IResource>();
-					if (folders.size() > 0) {
+					int size = folders.size();
+					if (size > 0 && size <= MAX_REFRESH_FOLDERS) {
 						for (String folder : folders) {
-							collectResource(folder, resources, monitor);
+							try {
+								collectResource(folder, resources, monitor);
+							}
+							catch (Exception ignore) {}
 						}
 					} else {
 						collectResource(NODE_MODULES, resources, monitor);

--- a/eclipse/terminal/ts.eclipse.ide.terminal.interpreter/src/ts/eclipse/ide/terminal/interpreter/EnvPath.java
+++ b/eclipse/terminal/ts.eclipse.ide.terminal.interpreter/src/ts/eclipse/ide/terminal/interpreter/EnvPath.java
@@ -3,6 +3,7 @@ package ts.eclipse.ide.terminal.interpreter;
 import java.io.File;
 import java.util.Map;
 
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.tm.terminal.view.core.interfaces.constants.ITerminalsConnectorConstants;
 import org.eclipse.tm.terminal.view.core.utils.Env;
 
@@ -59,5 +60,29 @@ public class EnvPath {
 			nativeEnvironmentPathCasePreserved = PATH_ENV;
 			return nativeEnvironmentPathCasePreserved;
 		}
+	}
+
+	/** Creates a OS-Dependent LineCommand to set the Path-Variable. */
+	public static LineCommand createSetPathCommand(String path) {
+		String os = Platform.getOS();
+		String command = null;
+		switch (os) {
+		case Platform.OS_WIN32:
+			command = "SET " + path;
+			break;
+		case Platform.OS_LINUX:
+		case Platform.OS_MACOSX:
+			command = "export " + path;
+			break;
+		//case Platform.OS_AIX:
+		//case Platform.OS_SOLARIS:
+		//case Platform.OS_HPUX:
+		//case Platform.OS_QNX:
+		default:
+			// Verification needed
+			command = "export" + path;
+			break;
+		}
+		return new LineCommand(command);
 	}
 }

--- a/eclipse/ts.eclipse.ide.ui/src/ts/eclipse/ide/internal/ui/wizards/NewTypeScriptProjectWizard.java
+++ b/eclipse/ts.eclipse.ide.ui/src/ts/eclipse/ide/internal/ui/wizards/NewTypeScriptProjectWizard.java
@@ -14,7 +14,6 @@ package ts.eclipse.ide.internal.ui.wizards;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -52,7 +51,6 @@ import com.google.gson.GsonBuilder;
 import ts.eclipse.ide.core.TypeScriptCorePlugin;
 import ts.eclipse.ide.core.utils.TypeScriptResourceUtil;
 import ts.eclipse.ide.internal.ui.TypeScriptUIMessages;
-import ts.eclipse.ide.terminal.interpreter.CommandTerminalService;
 import ts.eclipse.ide.terminal.interpreter.EnvPath;
 import ts.eclipse.ide.terminal.interpreter.LineCommand;
 import ts.eclipse.ide.ui.TypeScriptUIImageResource;
@@ -178,30 +176,18 @@ public class NewTypeScriptProjectWizard extends AbstractNewProjectWizard {
 
 				// Install TypeScript/tslint if needed
 				List<LineCommand> commands = new ArrayList<>();
-				mainPage.updateCommand(commands, preferences);
+				Map<String, Object> properties = new HashMap<String, Object>();
+				mainPage.updateCommand(commands, newProjectHandle);
 				tslintPage.updateCommand(commands, newProjectHandle);
 
 				if (!commands.isEmpty()) {
-					// Prepare terminal properties
-					String terminalId = "TypeScript Projects";
-					Map<String, Object> properties = new HashMap<String, Object>();
-					properties.put(ITerminalsConnectorConstants.PROP_TITLE, terminalId);
-					properties.put(ITerminalsConnectorConstants.PROP_ENCODING, StandardCharsets.UTF_8.name());
-					properties.put(ITerminalsConnectorConstants.PROP_PROCESS_WORKING_DIR,
-							projectLocationPath.toString());
-					properties.put(ITerminalsConnectorConstants.PROP_DELEGATE_ID,
-							"ts.eclipse.ide.terminal.interpreter.LocalInterpreterLauncherDelegate");
-					properties.put(ITerminalsConnectorConstants.PROP_TERMINAL_CONNECTOR_ID,
-							"org.eclipse.tm.terminal.connector.local.LocalConnector");
-
-					// Prepare environnement Path:
-					// - add nodejs directory
+					properties.put(ITerminalsConnectorConstants.PROP_PROCESS_WORKING_DIR, projectLocationPath.toString());
 					String nodeFilePath = getNodeFilePath();
 					if (!StringUtils.isEmpty(nodeFilePath)) {
 						EnvPath.insertToEnvPath(properties, nodeFilePath);
 					}
-					CommandTerminalService.getInstance().executeCommand(commands, terminalId, properties, null);
-
+					String terminalId = "TypeScript Projects";
+					executeCommandsInTerminal(terminalId, commands, properties);
 				}
 				try {
 					preferences.flush();

--- a/eclipse/ts.eclipse.ide.ui/src/ts/eclipse/ide/internal/ui/wizards/TSLintWizardPage.java
+++ b/eclipse/ts.eclipse.ide.ui/src/ts/eclipse/ide/internal/ui/wizards/TSLintWizardPage.java
@@ -30,7 +30,7 @@ import org.eclipse.swt.widgets.Combo;
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
- * 
+ *
  */
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
@@ -308,6 +308,7 @@ public class TSLintWizardPage extends AbstractWizardPage {
 
 	}
 
+	@Override
 	public void updateCommand(List<LineCommand> commands, IProject project) {
 		if (!useEmbeddedTslintRuntime) {
 			commands.add(new LineCommand(installTslintRuntime.getNpmInstallCommand()));
@@ -318,7 +319,7 @@ public class TSLintWizardPage extends AbstractWizardPage {
 					IFile tslintJsonFile = project.getFile("tslint.json");
 					try {
 						tslintJsonFile.refreshLocal(IResource.DEPTH_INFINITE, null);
-					} catch (CoreException e) {						
+					} catch (CoreException e) {
 						e.printStackTrace();
 					}
 				}

--- a/eclipse/ts.eclipse.ide.ui/src/ts/eclipse/ide/ui/wizards/AbstractNewProjectWizard.java
+++ b/eclipse/ts.eclipse.ide.ui/src/ts/eclipse/ide/ui/wizards/AbstractNewProjectWizard.java
@@ -15,9 +15,11 @@ package ts.eclipse.ide.ui.wizards;
 
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
 
@@ -43,6 +45,7 @@ import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.osgi.util.NLS;
+import org.eclipse.tm.terminal.view.core.interfaces.constants.ITerminalsConnectorConstants;
 import org.eclipse.ui.IPerspectiveDescriptor;
 import org.eclipse.ui.IPerspectiveRegistry;
 import org.eclipse.ui.IPluginContribution;
@@ -71,6 +74,8 @@ import org.eclipse.ui.statushandlers.StatusAdapter;
 import org.eclipse.ui.statushandlers.StatusManager;
 import org.eclipse.ui.wizards.newresource.BasicNewResourceWizard;
 
+import ts.eclipse.ide.terminal.interpreter.CommandTerminalService;
+import ts.eclipse.ide.terminal.interpreter.LineCommand;
 import ts.eclipse.ide.ui.TypeScriptUIPlugin;
 
 /**
@@ -306,6 +311,18 @@ public abstract class AbstractNewProjectWizard extends BasicNewResourceWizard im
 		selectAndReveal(newProject);
 
 		return true;
+	}
+
+	/** Executes the given Commands in a Terminal. */
+	protected void executeCommandsInTerminal(String terminalId, List<LineCommand> commands, Map<String, Object> properties) {
+		// Prepare terminal properties
+		properties.put(ITerminalsConnectorConstants.PROP_TITLE, terminalId);
+		properties.put(ITerminalsConnectorConstants.PROP_ENCODING, StandardCharsets.UTF_8.name());
+		properties.put(ITerminalsConnectorConstants.PROP_DELEGATE_ID,
+				"ts.eclipse.ide.terminal.interpreter.LocalInterpreterLauncherDelegate");
+		properties.put(ITerminalsConnectorConstants.PROP_TERMINAL_CONNECTOR_ID,
+				"org.eclipse.tm.terminal.connector.local.LocalConnector");
+		CommandTerminalService.getInstance().executeCommand(commands, terminalId, properties, null);
 	}
 
 	private static void replaceCurrentPerspective(IPerspectiveDescriptor persp) {

--- a/eclipse/ts.eclipse.ide.ui/src/ts/eclipse/ide/ui/wizards/AbstractWizardNewTypeScriptProjectCreationPage.java
+++ b/eclipse/ts.eclipse.ide.ui/src/ts/eclipse/ide/ui/wizards/AbstractWizardNewTypeScriptProjectCreationPage.java
@@ -13,6 +13,7 @@ package ts.eclipse.ide.ui.wizards;
 import java.io.File;
 import java.util.List;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
@@ -411,7 +412,7 @@ public abstract class AbstractWizardNewTypeScriptProjectCreationPage extends Wiz
 	}
 
 	/** Updates the Commands, which should be executed after creating the Project. */
-	public void updateCommand(List<LineCommand> commands, final IEclipsePreferences preferences) {
+	public void updateCommand(List<LineCommand> commands, IProject project) {
 	}
 
 	/** Class for the Status of the selected Node.js. */

--- a/eclipse/ts.eclipse.ide.ui/src/ts/eclipse/ide/ui/wizards/AbstractWizardNewTypeScriptProjectCreationPage.java
+++ b/eclipse/ts.eclipse.ide.ui/src/ts/eclipse/ide/ui/wizards/AbstractWizardNewTypeScriptProjectCreationPage.java
@@ -314,6 +314,7 @@ public abstract class AbstractWizardNewTypeScriptProjectCreationPage extends Wiz
 			nodeVersion.setText("");
 			nodePath.setText("");
 		}
+		nodeJsChanged(status.getNodeFile());
 		return status;
 	}
 
@@ -403,6 +404,10 @@ public abstract class AbstractWizardNewTypeScriptProjectCreationPage extends Wiz
 		installedNodeJs.setEnabled(!useEmbeddedNodeJs);
 		browseFileSystemButton.setEnabled(!useEmbeddedNodeJs);
 		browseWorkspaceButton.setEnabled(!useEmbeddedNodeJs);
+	}
+
+	/** The NodeJS-File has changed. */
+	protected void nodeJsChanged(File nodeFile) {
 	}
 
 	/** Updates the Commands, which should be executed after creating the Project. */

--- a/eclipse/ts.eclipse.ide.ui/src/ts/eclipse/ide/ui/wizards/AbstractWizardPage.java
+++ b/eclipse/ts.eclipse.ide.ui/src/ts/eclipse/ide/ui/wizards/AbstractWizardPage.java
@@ -11,6 +11,9 @@
  */
 package ts.eclipse.ide.ui.wizards;
 
+import java.util.List;
+
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -22,6 +25,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 
+import ts.eclipse.ide.terminal.interpreter.LineCommand;
 import ts.eclipse.ide.ui.utils.StatusUtil;
 import ts.eclipse.ide.ui.widgets.IStatusChangeListener;
 
@@ -79,4 +83,6 @@ public abstract class AbstractWizardPage extends WizardPage implements Listener,
 
 	protected abstract IStatus[] validatePage();
 
+	public void updateCommand(List<LineCommand> commands, IProject project) {
+	}
 }


### PR DESCRIPTION
I changed the API of the Project-Wizards and WizardPages:
- add `nodeJsChanged`-Hook, which is usefull to update NodeJs-Dependent things.
- add `AbstractNewProjectWizard#executeCommandsInTerminal` to be able to execute commands in a terminal.
- Add `AbstractWizardPage#updateCommand`
- If status of `NpmInstallWidget` changes, `AbstractWizardNewTypeScriptProjectCreationPage #validatePage()` is called to update the status of the `WizardPage`.

Also I changed a few things in `NpmInstallCommandInterpreter`:  
- Add `try-catch`-Block arround `collectResource(folder, resources, monitor);` to ignore invalid folders.
- If more then 20 folders should be refreshed, whole "node_modules"-folder is refreshed, since refreshing too many folders caused UI-Freeze.

Inside `EnvPath` there is now a function, which creates a OS-Dependent `LineCommand` to update the `PATH`.  
For windows it returns `SET PATH=new_path`.  
For all other OSes it returns `export PATH=new_path`.  
I could only test it for windows, so any feedback for other OSes is welcome!  

This PR needs to be merged before the one in angular2-eclipse, since that one needs the new API.