### PR TITLE
Preserve original file information

### DIFF
--- a/core/ts.core/src/ts/utils/ZipUtils.java
+++ b/core/ts.core/src/ts/utils/ZipUtils.java
@@ -102,6 +102,8 @@ public class ZipUtils {
 
 					// Close the stream
 					out.close();
+					// Preserve original modification date
+					extracted.setLastModified(entry.getTime());
 					if (extracted.getParent().contains(BIN_FOLDER)) {
 						extracted.setExecutable(true);
 					}
@@ -166,9 +168,13 @@ public class ZipUtils {
 
 					// Close the stream
 					out.close();
-					if (extractedFile.getParent().contains(BIN_FOLDER)) {
-						extractedFile.setExecutable(true);
-					}
+					// Preserve original modification date
+					extractedFile.setLastModified(entry.getTime());
+					long mode = entry.getMode(); 
+					if ((mode & 00100) > 0) { 
+						// Preserve execute permissions 
+						extractedFile.setExecutable(true, (mode & 00001) == 0); 
+					} 
 					break;
 				case TarEntry.LINK:
 					File linkFile = new File(destination, outFilename);


### PR DESCRIPTION
Looking for "bin" folder seems a bit "tricky" to me...
For tar files we should keep original executable permissions as this info is available.
For zip files executable information could be available for UNIX systems but in current ZipEntry implementation that info seems to be not available.