### PR TITLE
Fix possible NullPointer in IDETypeScriptRepositoryManager#getPath

### DIFF
--- a/eclipse/ts.eclipse.ide.core/src/ts/eclipse/ide/internal/core/repository/IDETypeScriptRepositoryManager.java
+++ b/eclipse/ts.eclipse.ide.core/src/ts/eclipse/ide/internal/core/repository/IDETypeScriptRepositoryManager.java
@@ -82,7 +82,8 @@ public class IDETypeScriptRepositoryManager extends TypeScriptRepositoryManager
 			// ${project_loc:node_modules/typescript
 			String projectPath = path.substring(PROJECT_LOC_TOKEN.length(),
 					path.endsWith(END_TOKEN) ? path.length() - 1 : path.length());
-			return project.getLocation().append(projectPath);
+			IPath location = project.getLocation();
+			return location != null ? location.append(projectPath) : null;
 		} else if (path.startsWith(WORKSPACE_LOC_TOKEN)) {
 			String wsPath = path.substring(WORKSPACE_LOC_TOKEN.length(),
 					path.endsWith(END_TOKEN) ? path.length() - 1 : path.length());


### PR DESCRIPTION
 project#getLocation returns null, when called during project-creation

In the Angular Project-Wizard I have now added the posibility to use global CLI-Preferences.  
If you use "$Project:" in that preference, you will get a NullPointerException, as the project does not (yet) exist.  
With this PR I added a null-check.